### PR TITLE
Use the registry as a cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,8 +41,7 @@ jobs:
           context: .
           load: true
           tags: ${{ env.TEST_TAG }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=${{ steps.image_name.outputs.registry }}/${{ steps.image_name.outputs.repository }}:latest
       - name: Test
         run: >-
           docker run --rm
@@ -69,5 +68,5 @@ jobs:
           push: ${{ github.event_name == 'push' && contains(github.ref, '/tags/v') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=${{ steps.image_name.outputs.registry }}/${{ steps.image_name.outputs.repository }}:latest
+          cache-to: type=inline


### PR DESCRIPTION
As seen in [this build](https://github.com/pyansys/pyansys-base-image/runs/3676116460?check_suite_focus=true) the cache did not work when tagging 0.6.2. Github has a maximum 5GB cache size, which is close to this image size.

Instead, use the latest tag as a cache with the "inline" strategy.