### PR TITLE
Upgrade the jupyter hub image to 1.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/base-notebook:hub-1.4.2
+FROM jupyter/base-notebook:hub-1.5.0
 
 MAINTAINER PyAnsys Maintainers "pyansys.maintainers@ansys.com"
 


### PR DESCRIPTION
The latest app version supported by the helm chart is now 1.5.0: https://jupyterhub.github.io/helm-chart/
Upgrade to this version