### PR TITLE
use application token

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,8 @@ jobs:
         with:
           application_id: ${{ secrets.BOT_APPLICATION_ID }}
           application_private_key: ${{ secrets.BOT_APPLICATION_PRIVATE_KEY }}
-          
+          permissions: "packages:write"
+
       - name: Login to ${{ env.REGISTRY }}
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
Update our GH Action to use the PyAnsys Bot, as configured here https://github.com/organizations/pyansys/settings/installations/22012868

Followed advice and directions from:
https://michaelheap.com/ultimate-guide-github-actions-authentication/
