### PR TITLE
Update the base image to lab-3.2.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/base-notebook:hub-2.0.1
+FROM jupyter/base-notebook:lab-3.2.9
 
 MAINTAINER PyAnsys Maintainers "pyansys.maintainers@ansys.com"
 


### PR DESCRIPTION
The initial intention of using a :hub tagged image was to keep a hard synchronization between the components.

The APOD team went for the latest lab tag, and this went well, so I'm doing the same change here.

The lab being the component we are interested in, there is no reason to create indirection with the hub versionning.